### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/mmit/learning.py
+++ b/mmit/learning.py
@@ -211,7 +211,7 @@ class MaxMarginIntervalTree(BaseEstimator, RegressorMixin):
             if node.depth != current_depth:
                 current_depth = node.depth
                 runtime_infos["depth"] = current_depth
-                logging.debug("The tree depth is %d" % current_depth)
+                logging.debug("The tree depth is {0:d}".format(current_depth))
                 if current_depth > 0:
                     level_callback(runtime_infos)
                 if current_depth == self.max_depth:
@@ -239,7 +239,7 @@ class MaxMarginIntervalTree(BaseEstimator, RegressorMixin):
                 continue
 
             # Perform the split
-            logging.debug("Splitting with rule %s." % node.rule)
+            logging.debug("Splitting with rule {0!s}.".format(node.rule))
             node.rule = stump
             node.left_child = left_child
             node.right_child = right_child
@@ -340,12 +340,12 @@ if __name__ == "__main__":
     print "Training set predictions:"
     print pred.predict(X)
     print
-    print "The tree contains %d rules:" % len(pred.tree_.rules)
+    print "The tree contains {0:d} rules:".format(len(pred.tree_.rules))
     print pred.tree_
     print
     print "The rule importances are:"
     for k, v in pred.rule_importances_.iteritems():
-        print "%s: %.3f" % (k, v)
+        print "{0!s}: {1:.3f}".format(k, v)
 
     print pred
     print pred.score(X, y)

--- a/mmit/model.py
+++ b/mmit/model.py
@@ -35,7 +35,7 @@ class DecisionStump(object):
         return (X[:, self.feature_idx] <= self.threshold).reshape(-1, )
 
     def __str__(self):
-        return "x[%d] <= %.4f" % (self.feature_idx, self.threshold)
+        return "x[{0:d}] <= {1:.4f}".format(self.feature_idx, self.threshold)
 
 
 class RegressionTreeNode(object):
@@ -111,9 +111,9 @@ class RegressionTreeNode(object):
         return len(_get_tree_rules(self))
 
     def __str__(self):
-        return "%s" % (
-            "Node(%s, %s, %s)" % (self.rule, self.left_child, self.right_child) if not (self.left_child is None)
-            else "Leaf(%.4f)" % self.predicted_value)
+        return "{0!s}".format((
+            "Node({0!s}, {1!s}, {2!s})".format(self.rule, self.left_child, self.right_child) if not (self.left_child is None)
+            else "Leaf({0:.4f})".format(self.predicted_value)))
 
 
 class TreeExporter(object):
@@ -131,36 +131,35 @@ def _latex_export(model):
     def _rec_export(node, depth):
         if not node.is_leaf:
             indent = "\t" * depth
-            return '\n%s %s[as=%s, nonterminal] -> {%s, %s}' % \
-                   (indent,
+            return '\n{0!s} {1!s}[as={2!s}, nonterminal] -> {{{3!s}, {4!s}}}'.format(indent,
                     str(hash((node.rule, node.parent))),
                     str(node.rule).replace("<=", "$\leq$").replace("[", "(").replace("]", ")"),
                     _rec_export(node.left_child, depth + 1),
                     _rec_export(node.right_child, depth + 1))
         else:
-            return "%s[as=Ex: $%d$\\\\Cost: $%.3f$\\\\Pred: $%.3f$, terminal]" % (str(hash(node)),
+            return "{0!s}[as=Ex: ${1:d}$\\\\Cost: ${2:.3f}$\\\\Pred: ${3:.3f}$, terminal]".format(str(hash(node)),
                                                                    node.n_examples,
                                                                    node.cost_value,
                                                                    node.predicted_value)
     exported = \
 """
-%% !TeX program = lualatex
-\\documentclass[tikz,border=5]{standalone}
-\\definecolor{nonterminal}{RGB}{230,230,230}
-\\definecolor{terminal}{RGB}{255,51,76}
-\\usetikzlibrary{shapes.misc, positioning}
-\\usetikzlibrary{graphs,graphdrawing,arrows.meta}
-\\usegdlibrary{trees}
-\\begin{document}
-\\begin{tikzpicture}[>=Stealth,
-                     nonterminal/.style={draw, fill=nonterminal, rounded rectangle, align=center},
-                     terminal/.style={draw, fill=terminal, rectangle, align=left}]
-\\graph[binary tree layout]{
-%s
-};
-\\end{tikzpicture}
-\\end{document}
-""" % _rec_export(model.tree_, 0)
+% !TeX program = lualatex
+\\documentclass[tikz,border=5]{{standalone}}
+\\definecolor{{nonterminal}}{{RGB}}{{230,230,230}}
+\\definecolor{{terminal}}{{RGB}}{{255,51,76}}
+\\usetikzlibrary{{shapes.misc, positioning}}
+\\usetikzlibrary{{graphs,graphdrawing,arrows.meta}}
+\\usegdlibrary{{trees}}
+\\begin{{document}}
+\\begin{{tikzpicture}}[>=Stealth,
+                     nonterminal/.style={{draw, fill=nonterminal, rounded rectangle, align=center}},
+                     terminal/.style={{draw, fill=terminal, rectangle, align=left}}]
+\\graph[binary tree layout]{{
+{0!s}
+}};
+\\end{{tikzpicture}}
+\\end{{document}}
+""".format(_rec_export(model.tree_, 0))
     print exported
 
 

--- a/mmit/pruning.py
+++ b/mmit/pruning.py
@@ -61,7 +61,7 @@ def min_cost_complexity_pruning(estimator):
                 return
             node = parents.pop()
             if np.allclose(node.cost_value, node.left_child.cost_value + node.right_child.cost_value):
-                logging.debug("Converting node %s into a leaf" % node)
+                logging.debug("Converting node {0!s} into a leaf".format(node))
                 del node.rule
                 node.rule = None
                 del node.left_child
@@ -118,7 +118,7 @@ def min_cost_complexity_pruning(estimator):
             min_gt, weakest_links = _find_weakest_links(root)
 
             # Prune the weakest link (and save alpha)
-            logging.debug("Pruning occurs at alpha %.9f" % min_gt)
+            logging.debug("Pruning occurs at alpha {0:.9f}".format(min_gt))
             for n in weakest_links:
                 del n.rule
                 n.rule = None

--- a/mmit/tests/test_solver.py
+++ b/mmit/tests/test_solver.py
@@ -90,15 +90,15 @@ def _random_testing(loss_degree):
             np.testing.assert_almost_equal(costs[-1], estimated_min, decimal=estimator_tol_decimals)
         except AssertionError:
             eprint()
-            eprint("Random test #%d -- Loss degree: %d" % (i + 1, loss_degree))
-            eprint("The margin is: %.4f" % margin)
+            eprint("Random test #{0:d} -- Loss degree: {1:d}".format(i + 1, loss_degree))
+            eprint("The margin is: {0:.4f}".format(margin))
             eprint("The lower and upper bounds are:")
-            eprint("Lower: %s" % target_lower.tolist())
-            eprint("Upper: %s" % target_upper.tolist())
-            eprint("All bounds: %s" % (
-                target_lower[~np.isinf(target_lower)].tolist() + target_upper[~np.isinf(target_upper)].tolist()))
-            eprint("All signs: %s" % ((np.ones((~np.isinf(target_lower)).sum()) * -1).tolist() + (
-            np.ones((~np.isinf(target_upper)).sum()).tolist())))
+            eprint("Lower: {0!s}".format(target_lower.tolist()))
+            eprint("Upper: {0!s}".format(target_upper.tolist()))
+            eprint("All bounds: {0!s}".format((
+                target_lower[~np.isinf(target_lower)].tolist() + target_upper[~np.isinf(target_upper)].tolist())))
+            eprint("All signs: {0!s}".format(((np.ones((~np.isinf(target_lower)).sum()) * -1).tolist() + (
+            np.ones((~np.isinf(target_upper)).sum()).tolist()))))
             eprint("Cost -- expected:", estimated_min, ", actual:", costs[-1])
             eprint("\n\n")
             raise AssertionError()


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:aldro61:mmit?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:aldro61:mmit?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)