### PR TITLE
INFINITY instead of isinf

### DIFF
--- a/mmit/core/solver.cpp
+++ b/mmit/core/solver.cpp
@@ -12,7 +12,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <cmath>
+#include <cmath> // for INFINITY
 #include <iostream>
 #include "coefficients.h"
 #include "double_utils.h"
@@ -99,7 +99,7 @@ int compute_optimal_cost(
         // Uncensored output
         if (equal(lower_vec[i], upper_vec[i]))
         {
-            if (!isinf(lower_vec[i]))
+            if (-INFINITY < lower_vec[i])
             {
                 Coefficients F1 = get_coefficients(lower_vec[i], 0., false, loss_type) * weights[i];
                 Coefficients F2 = get_coefficients(upper_vec[i], 0., true, loss_type) * weights[i];
@@ -112,7 +112,7 @@ int compute_optimal_cost(
         else
         {
             // Add the lower bound
-            if (!isinf(lower_vec[i]))
+            if (-INFINITY < lower_vec[i])
             {
                 Coefficients F = get_coefficients(lower_vec[i], margin, false, loss_type) * weights[i];
                 double b = get_breakpoint(lower_vec[i], margin, false);
@@ -120,7 +120,7 @@ int compute_optimal_cost(
             }
 
             // Add the upper bound
-            if (!isinf(upper_vec[i]))
+            if (upper_vec[i] < INFINITY)
             {
                 Coefficients F = get_coefficients(upper_vec[i], margin, true, loss_type) * weights[i];
                 double b = get_breakpoint(upper_vec[i], margin, true);


### PR DESCRIPTION
Hi @parismita @aldro61 I tried to compile mmit on windows/g++ and I got the following error message,

```
$ R CMD INSTALL Rpackage
* installing to library 'C:/Users/th798/R/win-library/3.6'
* installing *source* package 'mmit' ...
** using staged installation
** libs
c:/Rtools/mingw_64/bin/g++  -std=gnu++11 -I"C:/PROGRA~1/R/R-36~1.1/include" -DNDEBUG          -O2 -Wall  -mtune=generic -c interface.cpp -o interface.o
c:/Rtools/mingw_64/bin/g++  -std=gnu++11 -I"C:/PROGRA~1/R/R-36~1.1/include" -DNDEBUG          -O2 -Wall  -mtune=generic -c piecewise_function.cpp -o piecewise_function.o
c:/Rtools/mingw_64/bin/gcc  -I"C:/PROGRA~1/R/R-36~1.1/include" -DNDEBUG          -O2 -Wall  -std=gnu99 -mtune=generic -c registerDynamicSymbol.c -o registerDynamicSymbol.o
c:/Rtools/mingw_64/bin/g++  -std=gnu++11 -I"C:/PROGRA~1/R/R-36~1.1/include" -DNDEBUG          -O2 -Wall  -mtune=generic -c solver.cpp -o solver.o
solver.cpp: In function 'int compute_optimal_cost(int, double*, double*, double*, double, int, int*, double*, double*)':
solver.cpp:102:36: error: 'isinf' was not declared in this scope
             if (!isinf(lower_vec[i]))
                                    ^
solver.cpp:102:36: note: suggested alternative:
In file included from solver.cpp:15:0:
c:/Rtools/mingw_64/x86_64-w64-mingw32/include/c++/cmath:614:5: note:   'std::isinf'
     isinf(_Tp __x)
     ^
solver.cpp:115:36: error: 'isinf' was not declared in this scope
             if (!isinf(lower_vec[i]))
                                    ^
solver.cpp:115:36: note: suggested alternative:
In file included from solver.cpp:15:0:
c:/Rtools/mingw_64/x86_64-w64-mingw32/include/c++/cmath:614:5: note:   'std::isinf'
     isinf(_Tp __x)
     ^
solver.cpp:123:36: error: 'isinf' was not declared in this scope
             if (!isinf(upper_vec[i]))
                                    ^
solver.cpp:123:36: note: suggested alternative:
In file included from solver.cpp:15:0:
c:/Rtools/mingw_64/x86_64-w64-mingw32/include/c++/cmath:614:5: note:   'std::isinf'
     isinf(_Tp __x)
     ^
make: *** [solver.o] Error 1
ERROR: compilation failed for package 'mmit'
* removing 'C:/Users/th798/R/win-library/3.6/mmit'
```

which I fix in this PR by using INFINITY and -INFINITY instead of isinf. please review before I merge with master.